### PR TITLE
Potential fix for code scanning alert no. 71: Code injection

### DIFF
--- a/routes/trackOrder.ts
+++ b/routes/trackOrder.ts
@@ -15,7 +15,7 @@ module.exports = function trackOrder () {
     const id = utils.disableOnContainerEnv() ? String(req.params.id).replace(/[^\w-]+/g, '') : req.params.id
 
     challengeUtils.solveIf(challenges.reflectedXssChallenge, () => { return utils.contains(id, '<iframe src="javascript:alert(`xss`)">') })
-    db.orders.find({ $where: `this.orderId === '${id}'` }).then((order: any) => {
+    db.orders.find({ orderId: id }).then((order: any) => {
       const result = utils.queryResultToJson(order)
       challengeUtils.solveIf(challenges.noSqlOrdersChallenge, () => { return result.data.length > 1 })
       if (result.data[0] === undefined) {


### PR DESCRIPTION
Potential fix for [https://github.com/InfoTrackGlobal/juice-shop/security/code-scanning/71](https://github.com/InfoTrackGlobal/juice-shop/security/code-scanning/71)

In general, to fix this problem, avoid using `$where` (or any other code-evaluating mechanism) with strings built from user input. Instead, use standard field-based query operators that do not execute arbitrary JavaScript, passing user input as a value rather than as part of executable code. That way, user-controlled data only participates in data comparison, not in code evaluation.

For this specific code, the best fix without changing existing functionality is to replace the `$where` query with a direct equality query on `orderId`. The current code intends to find orders whose `orderId` matches the `id` route parameter. We can safely express this as `db.orders.find({ orderId: id })`, which avoids both JavaScript evaluation and string interpolation. This maintains behavior (returning all matching orders, allowing the NoSQL challenge check to still work) while removing the injection risk.

Concretely, in `routes/trackOrder.ts`, at line 18, replace:

```ts
db.orders.find({ $where: `this.orderId === '${id}'` }).then((order: any) => {
```

with:

```ts
db.orders.find({ orderId: id }).then((order: any) => {
```

No new imports or helper functions are needed, and no other lines in this file must change for the fix to work.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
