### PR TITLE
Potential fix for code scanning alert no. 70: Code injection

### DIFF
--- a/routes/showProductReviews.ts
+++ b/routes/showProductReviews.ts
@@ -31,7 +31,7 @@ module.exports = function productReviews () {
 
     // Measure how long the query takes, to check if there was a nosql dos attack
     const t0 = new Date().getTime()
-    db.reviews.find({ $where: 'this.product == ' + id }).then((reviews: Review[]) => {
+    db.reviews.find({ product: id }).then((reviews: Review[]) => {
       const t1 = new Date().getTime()
       challengeUtils.solveIf(challenges.noSqlCommandChallenge, () => { return (t1 - t0) > 2000 })
       const user = security.authenticatedUsers.from(req)


### PR DESCRIPTION
Potential fix for [https://github.com/InfoTrackGlobal/juice-shop/security/code-scanning/70](https://github.com/InfoTrackGlobal/juice-shop/security/code-scanning/70)

In general, code injection via MongoDB `$where` should be fixed by avoiding `$where` entirely and using structured query operators that treat user input as data, not code. Rather than building a JavaScript expression string like `'this.product == ' + id`, you should query on a field using `{ product: id }` (or with proper type conversion) so the driver handles the user value safely.

For this specific case, the best fix without changing behavior more than necessary is:

- Stop constructing a `$where` string using `id`.
- Replace the `$where` query with a normal field filter on `product`, using the same numeric conversion logic you already have:
  - When `utils.disableOnContainerEnv()` is true, `id` is a `number`.
  - Otherwise, `id` is a string.
- So we can query using `{ product: id }`, which will match documents whose `product` field equals this value (type-sensitive, which is appropriate). This removes the code execution aspect entirely.

Concretely:

- In `routes/showProductReviews.ts`, at line 34, replace:
  - `db.reviews.find({ $where: 'this.product == ' + id })`
- With:
  - `db.reviews.find({ product: id })`

No additional imports or helper methods are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
